### PR TITLE
Update go.mod to reference 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module lockboxkms
 
-go 1.23.2
+go 1.23
 
 require (
 	cloud.google.com/go/kms v1.20.1


### PR DESCRIPTION
Not referencing the minor version anymore